### PR TITLE
Fix for array param

### DIFF
--- a/rest_framework_datatables_editor/viewsets.py
+++ b/rest_framework_datatables_editor/viewsets.py
@@ -39,9 +39,16 @@ class EditorModelMixin(object):
                 read_date(data_in[1:], new_data_point, rest_of_line)
 
         data = {}
-        for (line, value) in post.items():
+        for (line, value) in post.lists():
             if line.startswith('data'):
                 line_data = re.findall(r"\[([^\[\]]*)\]", line)
+
+                if not line_data[-1]:
+                    del line_data[-1]
+
+                if len(value) == 1:
+                    value = value[0]
+
                 read_date(line_data, data, value)
         return data
 


### PR DESCRIPTION
I don't know how clumsy this method is, but it helps me in the next case:
```
{
  "action": "edit",
  "data[1][title]": "title",
  "data[1][files][]": 1,
  "data[1][files][]": 2,
  "data[1][files][]": 3
}
```
Existing tests pass successfully, but it's useful to cover the fix case as well.
